### PR TITLE
Create mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: Coding & Cupcakes 🍰
+theme:
+  name: material
+  palette:
+    primary: pink
+    accent: deep purple
+  font:
+    text: Roboto
+    code: Roboto Mono
+nav:
+  - Home: index.md
+  - Welcome: welcome.md
+  - Mindset Shift: mindset.md
+  - Copilot as Teacher: copilot-teacher.md
+  - Copilot as Pair Programmer: copilot-pair.md
+  - Copilot as Enabler: copilot-enabler.md
+  - Wrap-Up & Resources: wrapup.md


### PR DESCRIPTION
This pull request introduces a new configuration for the `mkdocs.yml` file to set up a documentation site. The changes include defining the site's name, theme, font, and navigation structure.

Site configuration:

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R1-R17): Set the site name to "Coding & Cupcakes 🍰" and configured the theme to use "material" with a pink primary palette and deep purple accent. Fonts were set to "Roboto" for text and "Roboto Mono" for code.

Navigation structure:

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R1-R17): Added navigation entries for various sections, including "Home," "Welcome," "Mindset Shift," "Copilot as Teacher," "Copilot as Pair Programmer," "Copilot as Enabler," and "Wrap-Up & Resources."